### PR TITLE
Changed the hashbang line to env

### DIFF
--- a/convertSTL.rb
+++ b/convertSTL.rb
@@ -1,4 +1,4 @@
-#!/usr/local/bin/ruby
+#!/usr/bin/env ruby
 # convertSTL.rb - Converts STL files between binary and ASCII encoding
 # by Chris Polis
 #


### PR DESCRIPTION
Using env in the hashbang means the script is more likely to run on other platforms without unnecessary alteration. 

Alteration required on Ubuntu 13.10.
